### PR TITLE
Fix Actions working directory

### DIFF
--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -1,10 +1,9 @@
-name: PHP Composer
+name: API
 
 on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -12,9 +11,12 @@ jobs:
 
     - name: Validate composer.json and composer.lock
       run: composer validate
+      working-directory: ./api
 
     - name: Install dependencies
       run: composer install --prefer-dist --no-progress --no-suggest
+      working-directory: ./api
 
     - name: Run test suite
-      run: composer run-script test
+      run: composer test
+      working-directory: ./api


### PR DESCRIPTION
We should use `working-directory` on Actions since this monorepo will serve other subprojects.