### PR TITLE
Hot-fit TypeScript

### DIFF
--- a/web/pages/_document.tsx
+++ b/web/pages/_document.tsx
@@ -1,19 +1,19 @@
-import Document from 'next/document'
+import Document, {DocumentContext} from 'next/document'
 import {ServerStyleSheet} from 'styled-components'
 import React from "react";
 
 export default class MyDocument extends Document {
-  static async getInitialProps(ctx) {
+  static async getInitialProps(context: DocumentContext) {
     const sheet = new ServerStyleSheet();
-    const originalRenderPage = ctx.renderPage;
+    const originalRenderPage = context.renderPage;
 
     try {
-      ctx.renderPage = () =>
+      context.renderPage = () =>
         originalRenderPage({
           enhanceApp: App => props => sheet.collectStyles(<App {...props} />)
         });
 
-      const initialProps = await Document.getInitialProps(ctx);
+      const initialProps = await Document.getInitialProps(context);
       return {
         ...initialProps,
         styles: (

--- a/web/tests/example.test.ts
+++ b/web/tests/example.test.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 test('example', () => {
   expect(1 + 1).toBe(2);
 });


### PR DESCRIPTION
Adding DocumentContext type and ignoring on the example test.